### PR TITLE
Refine Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
         os: [ ubuntu-latest, macos-latest, windows-latest ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,11 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: [8.3.0, 8, 10, 12, 14, 16, 18, 20, 22]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-
-    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os:
-  - linux
-  - osx
-  - windows
-language: node_js
-node_js:
-  - node
-  - '10'
-  - '8'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,12 @@ Changelog entries are classified using the following labels _(from [keep-a-chang
 
 ## [3.0.0] - 2018-04-08
 
-v3.0 is a complete refactor, resulting in a faster, smaller codebase, with fewer deps, and a more accurate parser and compiler. 
+v3.0 is a complete refactor, resulting in a faster, smaller codebase, with fewer deps, and a more accurate parser and compiler.
 
 **Breaking Changes**
 
 - The undocumented `.makeRe` method was removed
+- Require Node.js >= 8.3
 
 **Non-breaking changes**
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.3"
   },
   "scripts": {
     "test": "mocha -r ./test/mocha-initialization.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha -r ./test/mocha-initialization.js",
     "benchmark": "node benchmark"
   },
   "dependencies": {

--- a/test/braces.parse.js
+++ b/test/braces.parse.js
@@ -16,7 +16,7 @@ describe('braces.parse()', () => {
     it('should return an AST', () => {
       const ast = parse('a/{b,c}/d');
       const brace = ast.nodes.find(node => node.type === 'brace');
-      assert(brace);
+      assert.ok(brace);
       assert.equal(brace.nodes.length, 5);
     });
 
@@ -30,7 +30,7 @@ describe('braces.parse()', () => {
       const ast = parse('a/{a,b,[{c,d}]}/e');
       const brace = ast.nodes[2];
       const bracket = brace.nodes.find(node => node.value[0] === '[');
-      assert(bracket);
+      assert.ok(bracket);
       assert.equal(bracket.value, '[{c,d}]');
     });
   });

--- a/test/mocha-initialization.js
+++ b/test/mocha-initialization.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview
+ * This package works with node@8.3.0, which does not have support for `assert.strict`.
+ * This module is a shim to support these methods.
+ *
+ * @todo Remove this file when we drop support for node@8.3.0.
+ */
+const assert = require('assert');
+
+if (assert.strict === undefined) {
+  assert.strict = {
+    ok: assert.ok,
+    equal: assert.equal,
+    deepEqual: assert.deepEqual,
+    throws: assert.throws,
+  };
+}


### PR DESCRIPTION
- **Adds GitHub Actions CI, removes `.travis.yml`**
- **ci: specify supported versions Node.js**
- **ci: do not cancel CI jobs when the first job falls**
- **ci: run jobs only on ubuntu**
- **test: shim `assert.strict` for node@8.3.0**
- **fix(package): require Node.js 8.3+**
- **docs(CHANGELOG): refine required version of Node.js**
